### PR TITLE
Save .so to a folder named with the arch

### DIFF
--- a/joltik.py
+++ b/joltik.py
@@ -26,7 +26,9 @@ if __name__ == "__main__":
         f.write(pogo_apk.content)
     with zipfile.ZipFile("pogo.zip","r") as z:
         z.extract(f'lib/{ARCH}/libNianticLabsPlugin.so')
-    shutil.copyfile(f'./lib/{ARCH}/libNianticLabsPlugin.so', './pogo.so')
+    if not os.path.exists(ARCH):
+        os.makedirs(ARCH)
+    shutil.copyfile(f'./lib/{ARCH}/libNianticLabsPlugin.so', './' + ARCH + '/pogo.so')
     os.remove(f'./lib/{ARCH}/libNianticLabsPlugin.so')
     os.rmdir(f'./lib/{ARCH}')
     os.rmdir(f'./lib')


### PR DESCRIPTION
Little QoL for those like me with both archs
Let me know if you prefer me to just rename the .so, but I think there will be less user error this way.